### PR TITLE
Fix for issue #2 and resolved "Could not load file" error.

### DIFF
--- a/src/com/mostc/pftt/host/Host.java
+++ b/src/com/mostc/pftt/host/Host.java
@@ -39,22 +39,30 @@ public abstract class Host {
 	public abstract boolean equals(Object o);
 	
 	public boolean isSafePath(String path) {
-		if (path.equals(getJobWorkDir()))
-			// can't delete /php-sdk
-			return false;
 		String pftt_dir = getPfttDir();
-		if (path.startsWith(pftt_dir)) {
-			// don't delete anything in PFTT dir unless it is in job_work
-			if (!path.startsWith(System.getenv().get("PFTT_JOB_WORK")))
-				return false;
-		}
+		String job_work_dir = getJobWorkDir();
+
 		if (isWindows()) {
+			path = path.toLowerCase().replace("\\", "/");
+			pftt_dir = pftt_dir.toLowerCase().replace("\\", "/");
+			job_work_dir = job_work_dir.toLowerCase().replace("\\", "/");
+
 			// don't mess with windows
-			if (path.equals(getSystemDrive()+"\\Windows"))
+			if (path.equals(getSystemDrive().toLowerCase()+"/windows"))
 				return false;
 		} else {
 			// these dirs aren't safe to mess with
 			if (path.startsWith("/usr/")||path.startsWith("/var/")||path.startsWith("/lib/")||path.startsWith("/sbin/")||path.startsWith("/boot/"))
+				return false;
+		}
+
+		if (path.equals(job_work_dir))
+			// can't delete /php-sdk
+			return false;
+
+		if (path.startsWith(pftt_dir)) {
+			// don't delete anything in PFTT dir unless it is in job_work
+			if (!path.startsWith(job_work_dir))
 				return false;
 		}
 		return true;

--- a/src/com/mostc/pftt/host/Host.java
+++ b/src/com/mostc/pftt/host/Host.java
@@ -44,9 +44,8 @@ public abstract class Host {
 			return false;
 		String pftt_dir = getPfttDir();
 		if (path.startsWith(pftt_dir)) {
-			// don't delete anything in PFTT dir unless its in cache/working or job_work
-			if (!path.startsWith(pftt_dir+"/cache/working/") &&
-					!path.startsWith(pftt_dir+"\\job_work\\"))
+			// don't delete anything in PFTT dir unless it is in job_work
+			if (!path.startsWith(System.getenv().get("PFTT_JOB_WORK")))
 				return false;
 		}
 		if (isWindows()) {

--- a/src/com/mostc/pftt/host/Host.java
+++ b/src/com/mostc/pftt/host/Host.java
@@ -44,8 +44,9 @@ public abstract class Host {
 			return false;
 		String pftt_dir = getPfttDir();
 		if (path.startsWith(pftt_dir)) {
-			// don't delete anything in PFTT dir unless its in cache/working
-			if (!path.startsWith(pftt_dir+"/cache/working/"))
+			// don't delete anything in PFTT dir unless its in cache/working or job_work
+			if (!path.startsWith(pftt_dir+"/cache/working/") &&
+					!path.startsWith(pftt_dir+"\\job_work\\"))
 				return false;
 		}
 		if (isWindows()) {

--- a/src/com/mostc/pftt/main/PfttMain.java
+++ b/src/com/mostc/pftt/main/PfttMain.java
@@ -353,7 +353,7 @@ public class PfttMain {
 		System.out.println(" == Commands ==");
 		table = new AlignedTable(2, 85)
 			.addRow("core_all <build[,build2]> <test-pack>", "runs all tests in given test pack")
-			.addRow("core_named <build> <test-pack> <test name fragment>", "runs named tests or tests matching name pattern")
+			.addRow("core_named <build> <test-pack> <test name fragment>", "runs named tests or tests matching name pattern. Test name fragment is path from test-pack root to test file")
 			.addRow("core_list <build[,build2]> <test-pack> <file>", "runs list of tests stored in file")
 			.addRow("app_all <build[,build2]>", "runs all application tests specified in a Scenario config file against build")
 			.addRow("app_named <build[,build2]> <test name fragment>", "runs named application tests (tests specified in a Scenario config file)")

--- a/src/com/mostc/pftt/model/core/PhptTestCase.java
+++ b/src/com/mostc/pftt/model/core/PhptTestCase.java
@@ -767,6 +767,16 @@ public class PhptTestCase extends TestCase {
 			return ext_name;
 		
 		String[] parts = name.split("/");
+
+		try {
+			ext_name = parts[1];
+		} catch (ArrayIndexOutOfBoundsException e) {
+			System.err.println(e);
+			System.err.println("Extension name not found.");
+			System.err.println("Make sure <test fragment> argument is (folder in test-pack dir)/.../test.phpt");
+			System.exit(0);
+		}
+
 		return ext_name = parts[1];
 	}
 	


### PR DESCRIPTION
Added a bit more information for core_named to be more clear on what "test name fragment" meant. 

When loading the test-pack dir, the tool had an issue reading from the job_work dir. Modified code to let job_work directory be considered a safe path. 