### PR TITLE
Removed deprecated method involving Thread

### DIFF
--- a/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
+++ b/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
@@ -895,11 +895,6 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 										new_wsi = ((WebServerScenario)sapi_scenario).smgr.getWebServerInstance(cm, runner_fs, runner_host, scenario_set, build, 
 												group_key.getPhpIni(),
 												group_key.getEnv(),
-												// this instanceof PhpUnitThread ? //src_test_pack.getSourceDirectory()//
-														// yes definitely
-														// @see HttpPhpUnitTestCaseRunner#execute
-														// ((PhpUnitThread)this).my_temp_dir // TODO temp phpunit
-														// :
 												active_test_pack.getStorageDirectory(), thread_wsi, debugger_attached, completed_tests);
 										if (new_wsi!=thread_wsi && thread_wsi!=null) {
 											// be sure to close it or it will keep running (#getWebServerInstance doesn't close this)

--- a/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
+++ b/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
@@ -766,9 +766,6 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 				thread_wsi = null;
 			}
 			// interrupt thread to make it stop
-			try {
-				TestPackThread.this.stop(new TestTimeoutException());
-			} catch ( ThreadDeath ex ) {}
 			TestPackThread.this.interrupt();
 		}
 		
@@ -898,11 +895,11 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 										new_wsi = ((WebServerScenario)sapi_scenario).smgr.getWebServerInstance(cm, runner_fs, runner_host, scenario_set, build, 
 												group_key.getPhpIni(),
 												group_key.getEnv(),
-												this instanceof PhpUnitThread ? //src_test_pack.getSourceDirectory()//
+												// this instanceof PhpUnitThread ? //src_test_pack.getSourceDirectory()//
 														// yes definitely
 														// @see HttpPhpUnitTestCaseRunner#execute
-														((PhpUnitThread)this).my_temp_dir // TODO temp phpunit 
-														:
+														// ((PhpUnitThread)this).my_temp_dir // TODO temp phpunit
+														// :
 												active_test_pack.getStorageDirectory(), thread_wsi, debugger_attached, completed_tests);
 										if (new_wsi!=thread_wsi && thread_wsi!=null) {
 											// be sure to close it or it will keep running (#getWebServerInstance doesn't close this)


### PR DESCRIPTION
There was a part where there seemed to be a type mismatch and it was somehow working previously. However, the change to remove the deprecated method seemed to make the error pop up. Commented it out for the time being and tool still seems to work. 