### PR TITLE
Fixes #33

### DIFF
--- a/bin/pftt2_release.cmd
+++ b/bin/pftt2_release.cmd
@@ -7,12 +7,12 @@ CALL %~dp0set_env.cmd
 
 SET PFTT_LIB=%PFTT_HOME%\lib
 SET PFTT_BUILD=%PFTT_HOME%\build
+SET PFTT_RELEASE=%PFTT_HOME%\pftt_release
 
 REM Check if build directory exists
 if exist %PFTT_BUILD% (
 	REM Create pftt_release directory in main folder
 	md %PFTT_HOME%\pftt_release
-	SET PFTT_RELEASE=%PFTT_HOME%\pftt_release
 
 	REM Copy contents of bin, conf and lib to respective folders
 	md %PFTT_RELEASE%\bin


### PR DESCRIPTION
@weltling This is a very small change, but it seems that when we `SET PFTT_RELEASE = %PFTT_HOME%\pftt_release` in the middle of the code instead of at the beginning, it doesn't set it right away. Since it isn't set right away, it refers to `\bin` instead of `%PFTT_RELEASE%\bin`. 

This will make the script pack an empty dir instead of the required directories to make pftt run with minimal files. 