### PR TITLE
Exercise and check SKIPIF sections of PHPT test cases

### DIFF
--- a/src/com/mostc/pftt/runner/PhptTestPreparer.java
+++ b/src/com/mostc/pftt/runner/PhptTestPreparer.java
@@ -30,7 +30,7 @@ public class PhptTestPreparer {
 		prep.base_file_name = FileSystemScenario.basename(test_case.getBaseName()).replace("+", "");
 		
 		//
-		if (false /* TODO !AzureWebsitesScenario.check(fs) */) {
+		if (true /* TODO !AzureWebsitesScenario.check(fs) */) {
 			if (test_case.containsSection(EPhptSection.SKIPIF)) {
 				prep.skipif_file = host.joinIntoOnePath(prep.test_dir, prep.base_file_name + ".skip.php");
 					


### PR DESCRIPTION
Commit ca34269[1] inadvertently disabled exercising of SKIPIF sections.

[1] <http://git.php.net/?p=pftt2.git;a=commit;h=ca34269debeee8b3c192cfa3dd56a35b54be6d1b>