### PR TITLE
Fixes #43: Modified what files get deleted

### DIFF
--- a/src/com/mostc/pftt/model/core/PhptSourceTestPack.java
+++ b/src/com/mostc/pftt/model/core/PhptSourceTestPack.java
@@ -139,10 +139,15 @@ public class PhptSourceTestPack extends SourceTestPack<PhptActiveTestPack, PhptT
 		// clean out these files from the test-pack so they don't have to be stored or copied (to other hosts), etc...
 		// (when installing test-pack on another host, it should just copy all files so its identical, less variability.
 		//  also this improves performance for the installation process)
-		fs.deleteFileExtension(test_pack, ".skip.php");
+		fs.deleteFileExtension(test_pack, ".exp");
+		fs.deleteFileExtension(test_pack, ".out");
+		fs.deleteFileExtension(test_pack, ".log");
+		fs.deleteFileExtension(test_pack, ".zip");
+		fs.deleteFileExtension(test_pack, ".tar.gz");
 		fs.deleteFileExtension(test_pack, ".cmd");
 		fs.deleteFileExtension(test_pack, ".sh");
 		fs.deleteFileExtension(test_pack, ".clean.php");
+		fs.deleteFileExtension(test_pack, ".skip.php");
 		fs.deleteFileExtension(test_pack, ".tmp");
 		// don't delete .php (specifically run-test.php) in root of test-pack (user may want it later)
 		IFileChooser PHP_CHOOSER = new IFileChooser() {

--- a/src/com/mostc/pftt/runner/AbstractPhptTestCaseRunner.java
+++ b/src/com/mostc/pftt/runner/AbstractPhptTestCaseRunner.java
@@ -228,6 +228,7 @@ public abstract class AbstractPhptTestCaseRunner extends AbstractTestCaseRunner<
 	protected void removeTempFiles() throws IllegalStateException, IOException {
 		fs.deleteIfExists(prep.test_clean);
 		fs.deleteIfExists(prep.test_file);
+		fs.deleteIfExists(prep.skipif_file);
 		fs.deleteIfExists(prep.test_dir + "\\" + prep.base_file_name + ".php.cmd");
 	}
 	


### PR DESCRIPTION
Updated following files to delete the temp SKIPIF files before a run starts and when a test succeeds. Also noticed that there were a few files left over from run-test.php, so added a few more extensions to be deleted before a run starts. 

@weltling Could you check this? I'm actually not sure why it says I replaced the whole file when I only changed a few lines for `PhptSourceTestPack.java`. Changes I made were lines 142-151. 