### PR TITLE
Fixes #53: Created batch files

### DIFF
--- a/bin/get_latest_revision.cmd
+++ b/bin/get_latest_revision.cmd
@@ -1,0 +1,10 @@
+set SNAP_JSON=php-%branch%.json
+set SNAP_JSON_URL=https://windows.php.net/downloads/snaps/php-%branch%/%SNAP_JSON%
+bitsadmin /transfer DownloadingJson /download /priority high !SNAP_JSON_URL! %PFTT_CACHE%\!SNAP_JSON!
+
+set "psCmd="add-type -As System.Web.Extensions;^
+$JSON = new-object Web.Script.Serialization.JavaScriptSerializer;^
+$JSON.DeserializeObject($input).revision_last_exported""
+
+for /f %%I in ('^<"%PFTT_CACHE%\!SNAP_JSON!" powershell -noprofile %psCmd%') do set "revision=r%%I"
+del %PFTT_CACHE%\!SNAP_JSON!

--- a/bin/get_qa.cmd
+++ b/bin/get_qa.cmd
@@ -1,0 +1,81 @@
+@ECHO OFF
+setlocal enabledelayedexpansion
+
+set branch=%1
+set build=%2
+set cpu=%3
+
+REM Check if parameters are set
+if %branch%.==. GOTO args_error
+if %build%.==. GOTO args_error
+if %cpu%.==. (
+	GOTO args_error
+) else (
+	GOTO set_env
+)
+
+:args_error
+echo User error: must specify branch, build type, CPU arch and revision code
+echo get_release "<branch> <build> <cpu>"
+echo Branch can be any of: 5.6.XRCX, 7.0.XRCX, 7.1.XRCX, 7.2.XRCX, 7.3.XRCX, 7.4.XRCX
+echo Build can be any of: NTS, TS
+echo CPU can be any of: X64, X86
+exit /b
+
+:set_env
+REM set important env vars
+IF DEFINED PFTT_SHELL GOTO :skip_set_env
+CALL %~dp0set_env.cmd
+:skip_set_env
+
+SET PHP_BUILDS=%~d0\PHPBuilds
+
+REM Create cache folder if it does not exist
+if not exist %PHP_BUILDS% (
+	md %~d0\PHPBuilds
+)
+
+set file_name=php-%branch%
+set test_pack=php-test-pack-%branch%
+
+REM Add nts to file_name if needed
+if /I %build%==nts (
+	set file_name=%file_name%-nts
+)
+
+REM Set file_name based on parameters
+if not x%branch:5.6=%==x%branch% (
+	set file_name=%file_name%-win32-vc11-%cpu%
+) else if not x%branch:7.0=%==x%branch% (
+	set file_name=%file_name%-win32-vc14-%cpu%
+) else if not x%branch:7.1=%==x%branch% (
+	set file_name=%file_name%-win32-vc14-%cpu%
+) else if not x%branch:7.2=%==x%branch% (
+	set file_name=%file_name%-win32-vc15-%cpu%
+) else if not x%branch:7.3=%==x%branch% (
+	set file_name=%file_name%-win32-vc15-%cpu%
+) else if not x%branch:7.4=%==x%branch% (
+	set file_name=%file_name%-win32-vs16-%cpu%
+)
+
+REM Download the build if it is not available
+if not exist %PHP_BUILDS%\%file_name% (
+	set build_link=https://windows.php.net/downloads/qa/%file_name%.zip
+
+	bitsadmin /transfer DownloadingQABuild /download /priority high !build_link! %PFTT_CACHE%\%file_name%.zip
+	7za.exe x %PFTT_CACHE%\%file_name%.zip -o%PHP_BUILDS%\*
+	del %PFTT_CACHE%\%file_name%.zip
+) else (
+	echo QA build already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
+)
+
+REM Also download test-pack if it is not available
+if not exist %PHP_BUILDS%\%test_pack% (
+	set test_pack_link=https://windows.php.net/downloads/qa/%test_pack%.zip
+
+	bitsadmin /transfer DownloadingQATestPack /download /priority high !test_pack_link! %PFTT_CACHE%\%test_pack%.zip
+	7za.exe x %PFTT_CACHE%\%test_pack%.zip -o%PHP_BUILDS%\*
+	del %PFTT_CACHE%\%test_pack%.zip
+) else (
+	echo Test pack already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
+)

--- a/bin/get_qa.cmd
+++ b/bin/get_qa.cmd
@@ -17,7 +17,7 @@ if %cpu%.==. (
 :args_error
 echo User error: must specify branch, build type, CPU arch and revision code
 echo get_release "<branch> <build> <cpu>"
-echo Branch can be any of: 5.6.XRCX, 7.0.XRCX, 7.1.XRCX, 7.2.XRCX, 7.3.XRCX, 7.4.XRCX
+echo Branch can be any of: 7.2.XRCX, 7.3.XRCX, 7.4.XRCX
 echo Build can be any of: NTS, TS
 echo CPU can be any of: X64, X86
 exit /b

--- a/bin/get_qa.cmd
+++ b/bin/get_qa.cmd
@@ -44,13 +44,7 @@ if /I %build%==nts (
 )
 
 REM Set file_name based on parameters
-if not x%branch:5.6=%==x%branch% (
-	set file_name=%file_name%-win32-vc11-%cpu%
-) else if not x%branch:7.0=%==x%branch% (
-	set file_name=%file_name%-win32-vc14-%cpu%
-) else if not x%branch:7.1=%==x%branch% (
-	set file_name=%file_name%-win32-vc14-%cpu%
-) else if not x%branch:7.2=%==x%branch% (
+if not x%branch:7.2=%==x%branch% (
 	set file_name=%file_name%-win32-vc15-%cpu%
 ) else if not x%branch:7.3=%==x%branch% (
 	set file_name=%file_name%-win32-vc15-%cpu%

--- a/bin/get_release.cmd
+++ b/bin/get_release.cmd
@@ -44,11 +44,7 @@ if /I %build%==nts (
 )
 
 REM Set file_name based on parameters
-if %branch%==5.6 (
-	set file_name=%file_name%-win32-vc11-%cpu%-latest
-) else if %branch%==7.0 (
-	set file_name=%file_name%-win32-vc14-%cpu%-latest
-) else if %branch%==7.1 (
+if %branch%==7.1 (
 	set file_name=%file_name%-win32-vc14-%cpu%-latest
 ) else if %branch%==7.2 (
 	set file_name=%file_name%-win32-vc15-%cpu%-latest

--- a/bin/get_release.cmd
+++ b/bin/get_release.cmd
@@ -17,7 +17,7 @@ if %cpu%.==. (
 :args_error
 echo User error: must specify branch, build type, CPU arch and revision code
 echo get_release "<branch> <build> <cpu>"
-echo Branch can be any of: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4
+echo Branch can be any of: 7.1, 7.2, 7.3, 7.4
 echo Build can be any of: NTS, TS
 echo CPU can be any of: X64, X86
 exit /b

--- a/bin/get_release.cmd
+++ b/bin/get_release.cmd
@@ -1,0 +1,81 @@
+@ECHO OFF
+setlocal enabledelayedexpansion
+
+set branch=%1
+set build=%2
+set cpu=%3
+
+REM Check if parameters are set
+if %branch%.==. GOTO args_error
+if %build%.==. GOTO args_error
+if %cpu%.==. (
+	GOTO args_error
+) else (
+	GOTO set_env
+)
+
+:args_error
+echo User error: must specify branch, build type, CPU arch and revision code
+echo get_release "<branch> <build> <cpu>"
+echo Branch can be any of: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4
+echo Build can be any of: NTS, TS
+echo CPU can be any of: X64, X86
+exit /b
+
+:set_env
+REM set important env vars
+IF DEFINED PFTT_SHELL GOTO :skip_set_env
+CALL %~dp0set_env.cmd
+:skip_set_env
+
+SET PHP_BUILDS=%~d0\PHPBuilds
+
+REM Create cache folder if it does not exist
+if not exist %PHP_BUILDS% (
+	md %~d0\PHPBuilds
+)
+
+set file_name=php-%branch%
+set test_pack=php-test-pack-%branch%-latest
+
+REM Add nts to file_name if needed
+if /I %build%==nts (
+	set file_name=%file_name%-nts
+)
+
+REM Set file_name based on parameters
+if %branch%==5.6 (
+	set file_name=%file_name%-win32-vc11-%cpu%-latest
+) else if %branch%==7.0 (
+	set file_name=%file_name%-win32-vc14-%cpu%-latest
+) else if %branch%==7.1 (
+	set file_name=%file_name%-win32-vc14-%cpu%-latest
+) else if %branch%==7.2 (
+	set file_name=%file_name%-win32-vc15-%cpu%-latest
+) else if %branch%==7.3 (
+	set file_name=%file_name%-win32-vc15-%cpu%-latest
+) else if %branch%==7.4 (
+	set file_name=%file_name%-win32-vs16-%cpu%-latest
+)
+
+REM Download the build if it is not available
+if not exist %PHP_BUILDS%\%file_name% (
+	set build_link=https://windows.php.net/downloads/releases/latest/%file_name%.zip
+
+	bitsadmin /transfer DownloadingReleaseBuild /download /priority high !build_link! %PFTT_CACHE%\%file_name%.zip
+	7za.exe x %PFTT_CACHE%\%file_name%.zip -o%PHP_BUILDS%\*
+	del %PFTT_CACHE%\%file_name%.zip
+) else (
+	echo Release build already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
+)
+
+REM Also download test-pack if it is not available
+if not exist %PHP_BUILDS%\%test_pack% (
+	set test_pack_link=https://windows.php.net/downloads/releases/latest/%test_pack%.zip
+
+	bitsadmin /transfer DownloadingReleaseTestPack /download /priority high !test_pack_link! %PFTT_CACHE%\%test_pack%.zip
+	7za.exe x %PFTT_CACHE%\%test_pack%.zip -o%PHP_BUILDS%\*
+	del %PFTT_CACHE%\%test_pack%.zip
+) else (
+	echo Test pack already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
+)

--- a/bin/get_snapshot.cmd
+++ b/bin/get_snapshot.cmd
@@ -1,0 +1,101 @@
+@ECHO OFF
+setlocal enabledelayedexpansion
+
+set branch=%1
+set build=%2
+set cpu=%3
+set revision=%4
+
+REM Check if parameters are set
+if %branch%.==. GOTO args_error
+if %build%.==. GOTO args_error
+if %cpu%.==. GOTO args_error
+if %revision%.==. (
+	GOTO args_error
+) else (
+	GOTO set_env
+)
+
+:args_error
+echo User error: must specify branch, build type, CPU arch and revision code
+echo get_release "<branch> <build> <cpu> <revision code | latest>"
+echo Branch can be any of: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4
+echo Build can be any of: NTS, TS
+echo CPU can be any of: X64, X86
+echo Revision code starts with r (i.e. rxxxxxx)
+exit /b
+
+:set_env
+REM set important env vars
+IF DEFINED PFTT_SHELL GOTO :skip_set_env
+CALL %~dp0set_env.cmd
+:skip_set_env
+
+SET PHP_BUILDS=%~d0\PHPBuilds
+
+REM Create cache folder if it does not exist
+if not exist %PHP_BUILDS% (
+	md %~d0\PHPBuilds
+)
+
+REM Set file_name and test_pack based on parameters
+if %branch%==5.6 (
+	set file_name=php-!branch!-%build%-windows-vc11-%cpu%
+	set test_pack=php-test-pack-!branch!-%build%-windows-vc11-%cpu%
+) else if %branch%==7.0 (
+	set file_name=php-!branch!-%build%-windows-vc14-%cpu%
+	set test_pack=php-test-pack-!branch!-%build%-windows-vc14-%cpu%
+) else if %branch%==7.1 (
+	set file_name=php-!branch!-%build%-windows-vc14-%cpu%
+	set test_pack=php-test-pack-!branch!-%build%-windows-vc14-%cpu%
+) else if %branch%==7.2 (
+	set file_name=php-!branch!-%build%-windows-vc15-%cpu%
+	set test_pack=php-test-pack-!branch!-%build%-windows-vc15-%cpu%
+) else if %branch%==7.3 (
+	set file_name=php-!branch!-%build%-windows-vc15-%cpu%
+	set test_pack=php-test-pack-!branch!-%build%-windows-vc15-%cpu%
+) else if %branch%==7.4 (
+	set file_name=php-!branch!-%build%-windows-vs16-%cpu%
+	set test_pack=php-test-pack-!branch!-%build%-windows-vs16-%cpu%
+)
+
+if /i %revision%==latest goto get_latest_revision
+
+:get_files
+set file_name=%file_name%-%revision%
+set test_pack=%test_pack%-%revision%
+
+REM Download the build if it is not available
+if not exist %PHP_BUILDS%\%file_name% (
+	set build_link=https://windows.php.net/downloads/snaps/php-%branch%/%revision%/%file_name%.zip
+
+	bitsadmin /transfer DownloadingSnapBuild /download /priority high !build_link! %PFTT_CACHE%\%file_name%.zip
+	7za.exe x %PFTT_CACHE%\%file_name%.zip -o%PHP_BUILDS%\*
+	del %PFTT_CACHE%\%file_name%.zip
+) else (
+	echo Snap build already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
+)
+
+REM Also download test-pack if it is not available
+if not exist %PHP_BUILDS%\%test_pack% (
+	set test_pack_link=https://windows.php.net/downloads/snaps/php-%branch%/%revision%/%test_pack%.zip
+
+	bitsadmin /transfer DownloadingSnapTestPack /download /priority high !test_pack_link! %PFTT_CACHE%\%test_pack%.zip
+	7za.exe x %PFTT_CACHE%\%test_pack%.zip -o%PHP_BUILDS%\*
+	del %PFTT_CACHE%\%test_pack%.zip
+) else (
+	echo Test pack already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
+)
+exit /b
+
+:get_latest_revision
+set SNAP_JSON=php-%branch%.json
+set SNAP_JSON_URL=https://windows.php.net/downloads/snaps/php-%branch%/%SNAP_JSON%
+bitsadmin /transfer DownloadingRelease /download /priority high !SNAP_JSON_URL! %PFTT_CACHE%\!SNAP_JSON!
+
+set "psCmd="add-type -As System.Web.Extensions;^
+$JSON = new-object Web.Script.Serialization.JavaScriptSerializer;^
+$JSON.DeserializeObject($input).revision_last_exported""
+
+for /f %%I in ('^<"%PFTT_CACHE%\!SNAP_JSON!" powershell -noprofile %psCmd%') do set "revision=r%%I"
+goto get_files

--- a/bin/get_snapshot.cmd
+++ b/bin/get_snapshot.cmd
@@ -19,7 +19,7 @@ if %revision%.==. (
 :args_error
 echo User error: must specify branch, build type, CPU arch and revision code
 echo get_release "<branch> <build> <cpu> <revision code | latest>"
-echo Branch can be any of: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4
+echo Branch can be any of: 7.1, 7.2, 7.3, 7.4
 echo Build can be any of: NTS, TS
 echo CPU can be any of: X64, X86
 echo Revision code starts with r (i.e. rxxxxxx)
@@ -40,28 +40,27 @@ if not exist %PHP_BUILDS% (
 
 REM Set file_name and test_pack based on parameters
 if %branch%==5.6 (
-	set file_name=php-!branch!-%build%-windows-vc11-%cpu%
-	set test_pack=php-test-pack-!branch!-%build%-windows-vc11-%cpu%
+	set file_name=php-%branch%-%build%-windows-vc11-%cpu%
+	set test_pack=php-test-pack-%branch%-%build%-windows-vc11-%cpu%
 ) else if %branch%==7.0 (
-	set file_name=php-!branch!-%build%-windows-vc14-%cpu%
-	set test_pack=php-test-pack-!branch!-%build%-windows-vc14-%cpu%
+	set file_name=php-%branch%-%build%-windows-vc14-%cpu%
+	set test_pack=php-test-pack-%branch%-%build%-windows-vc14-%cpu%
 ) else if %branch%==7.1 (
-	set file_name=php-!branch!-%build%-windows-vc14-%cpu%
-	set test_pack=php-test-pack-!branch!-%build%-windows-vc14-%cpu%
+	set file_name=php-%branch%-%build%-windows-vc14-%cpu%
+	set test_pack=php-test-pack-%branch%-%build%-windows-vc14-%cpu%
 ) else if %branch%==7.2 (
-	set file_name=php-!branch!-%build%-windows-vc15-%cpu%
-	set test_pack=php-test-pack-!branch!-%build%-windows-vc15-%cpu%
+	set file_name=php-%branch%-%build%-windows-vc15-%cpu%
+	set test_pack=php-test-pack-%branch%-%build%-windows-vc15-%cpu%
 ) else if %branch%==7.3 (
-	set file_name=php-!branch!-%build%-windows-vc15-%cpu%
-	set test_pack=php-test-pack-!branch!-%build%-windows-vc15-%cpu%
+	set file_name=php-%branch%-%build%-windows-vc15-%cpu%
+	set test_pack=php-test-pack-%branch%-%build%-windows-vc15-%cpu%
 ) else if %branch%==7.4 (
-	set file_name=php-!branch!-%build%-windows-vs16-%cpu%
-	set test_pack=php-test-pack-!branch!-%build%-windows-vs16-%cpu%
+	set file_name=php-%branch%-%build%-windows-vs16-%cpu%
+	set test_pack=php-test-pack-%branch%-%build%-windows-vs16-%cpu%
 )
 
-if /i %revision%==latest goto get_latest_revision
+if /i %revision%==latest call get_latest_revision.cmd
 
-:get_files
 set file_name=%file_name%-%revision%
 set test_pack=%test_pack%-%revision%
 
@@ -86,16 +85,3 @@ if not exist %PHP_BUILDS%\%test_pack% (
 ) else (
 	echo Test pack already exists. Remove or move file in %PHP_BUILDS% if you want new copy.
 )
-exit /b
-
-:get_latest_revision
-set SNAP_JSON=php-%branch%.json
-set SNAP_JSON_URL=https://windows.php.net/downloads/snaps/php-%branch%/%SNAP_JSON%
-bitsadmin /transfer DownloadingRelease /download /priority high !SNAP_JSON_URL! %PFTT_CACHE%\!SNAP_JSON!
-
-set "psCmd="add-type -As System.Web.Extensions;^
-$JSON = new-object Web.Script.Serialization.JavaScriptSerializer;^
-$JSON.DeserializeObject($input).revision_last_exported""
-
-for /f %%I in ('^<"%PFTT_CACHE%\!SNAP_JSON!" powershell -noprofile %psCmd%') do set "revision=r%%I"
-goto get_files

--- a/bin/get_snapshot.cmd
+++ b/bin/get_snapshot.cmd
@@ -39,13 +39,7 @@ if not exist %PHP_BUILDS% (
 )
 
 REM Set file_name and test_pack based on parameters
-if %branch%==5.6 (
-	set file_name=php-%branch%-%build%-windows-vc11-%cpu%
-	set test_pack=php-test-pack-%branch%-%build%-windows-vc11-%cpu%
-) else if %branch%==7.0 (
-	set file_name=php-%branch%-%build%-windows-vc14-%cpu%
-	set test_pack=php-test-pack-%branch%-%build%-windows-vc14-%cpu%
-) else if %branch%==7.1 (
+if %branch%==7.1 (
 	set file_name=php-%branch%-%build%-windows-vc14-%cpu%
 	set test_pack=php-test-pack-%branch%-%build%-windows-vc14-%cpu%
 ) else if %branch%==7.2 (


### PR DESCRIPTION
Created 3 separate batch file to get builds from release, QA and snapshot branches. 

Each batch file has slightly different implementations because of how the names were setup. 

@weltling @cmb69 Could  you two check if these are good as is? I have been using them and it seems to work fine so far. One thing I was unsure about was which branches to include. I included the branches that I saw on the snaps branch (excluding ostc and master). 