### PR TITLE
Remove unsupported ini directives

### DIFF
--- a/src/com/mostc/pftt/model/core/PhpIni.java
+++ b/src/com/mostc/pftt/model/core/PhpIni.java
@@ -41,7 +41,6 @@ public class PhpIni {
 	public static final String EXTENSION_DIR = "extension_dir";
 	public static final String OUTPUT_HANDLER = "output_handler";
 	public static final String OPEN_BASEDIR = "open_basedir";
-	public static final String SAFE_MODE = "safe_mode";
 	public static final String DISABLE_DEFS = "disable_defs";
 	public static final String OUTPUT_BUFFERING = "output_buffering";
 	public static final String ERROR_REPORTING = "error_reporting";
@@ -58,13 +57,8 @@ public class PhpIni {
 	public static final String ERROR_APPEND_STRING = "error_append_string";
 	public static final String AUTO_PREPEND_FILE = "auto_prepend_file";
 	public static final String AUTO_APPEND_FILE = "auto_append_file";
-	public static final String MAGIC_QUOTES_RUNTIME = "magic_quotes_runtime";
 	public static final String IGNORE_REPEATED_ERRORS = "ignore_repeated_errors";
 	public static final String PRECISION = "precision";
-	public static final String UNICODE_RUNTIME_ENCODING = "unicode.runtime_encoding";
-	public static final String UNICODE_SCRIPT_ENCODING = "unicode.script_encoding";
-	public static final String UNICODE_OUTPUT_ENCODING = "unicode.output_encoding";
-	public static final String UNICODE_FROM_ERROR_MODE = "unicode.from_error_mode";
 	public static final String SESSION_AUTO_START = "session.auto_start";
 	public static final String SYS_TEMP_DIR = "sys_temp_dir";
 	public static final String ON = "On";

--- a/src/com/mostc/pftt/model/smoke/RequiredExtensionsSmokeTest.java
+++ b/src/com/mostc/pftt/model/smoke/RequiredExtensionsSmokeTest.java
@@ -210,7 +210,6 @@ public class RequiredExtensionsSmokeTest extends SmokeTest {
 		// ini.putSingle("date.timezone", "'UTC'");
 		ini.putMulti(PhpIni.OUTPUT_HANDLER, StringUtil.EMPTY);
 		ini.putMulti(PhpIni.OPEN_BASEDIR, StringUtil.EMPTY);
-		ini.putMulti(PhpIni.SAFE_MODE, 0);
 		ini.putMulti(PhpIni.DISABLE_DEFS, PhpIni.OFF);
 		ini.putMulti(PhpIni.OUTPUT_BUFFERING, PhpIni.ON);
 		
@@ -252,13 +251,8 @@ public class RequiredExtensionsSmokeTest extends SmokeTest {
 		ini.putMulti(PhpIni.ERROR_APPEND_STRING, StringUtil.EMPTY);
 		ini.putMulti(PhpIni.AUTO_PREPEND_FILE, StringUtil.EMPTY);
 		ini.putMulti(PhpIni.AUTO_APPEND_FILE, StringUtil.EMPTY);
-		ini.putMulti(PhpIni.MAGIC_QUOTES_RUNTIME, PhpIni.OFF);
 		ini.putMulti(PhpIni.IGNORE_REPEATED_ERRORS, PhpIni.OFF);
 		ini.putMulti(PhpIni.PRECISION, 14);
-		ini.putMulti(PhpIni.UNICODE_RUNTIME_ENCODING, PhpIni.ISO_8859_1);
-		ini.putMulti(PhpIni.UNICODE_SCRIPT_ENCODING, PhpIni.UTF_8);
-		ini.putMulti(PhpIni.UNICODE_OUTPUT_ENCODING, PhpIni.UTF_8);
-		ini.putMulti(PhpIni.UNICODE_FROM_ERROR_MODE, PhpIni.U_INVALID_SUBSTITUTE);
 		ini.putMulti(PhpIni.SESSION_AUTO_START, PhpIni.OFF);
 		// added sys_temp_dir for PHAR PHPTs - otherwise they'll use CWD for their temp dir
 		// even if its on a remote file system (slow & buggy)


### PR DESCRIPTION
`safe_mode` and `magic_quotes_runtime` are unsupported as of PHP 5.4.0;
the `unicde.*` directives have been a PHP 6 thing.  No need to keep
them.