### PR TITLE
Fix #63: Mbstring tests charset issue

### DIFF
--- a/src/com/github/mattficken/io/AbstractDetectingCharsetReader.java
+++ b/src/com/github/mattficken/io/AbstractDetectingCharsetReader.java
@@ -26,7 +26,7 @@ public abstract class AbstractDetectingCharsetReader extends AbstractReader {
 	WeakHashMap<Charset,CharsetEncoder> ce_map = new WeakHashMap<Charset,CharsetEncoder>();
 	public CharsetEncoder ce;
 	CharsetDecoderICU cd;
-	public CharsetRecognizer[] recogs = CharsetDeciderDecoder.EXPRESS_RECOGNIZERS;//.ALL_RECOGNIZERS; // TODO
+	public CharsetRecognizer[] recogs = CharsetDeciderDecoder.FIXED;//.ALL_RECOGNIZERS; // TODO
 	CharsetRec hc_cm = null; // TODO usually start over for each #detectCharset call
 	protected void detectCharset(byte[] bytes, int off, int len) {
 		bytes = IOUtil.ensureLeftShifted(bytes, off, len);

--- a/src/com/github/mattficken/io/CharsetDeciderDecoder.java
+++ b/src/com/github/mattficken/io/CharsetDeciderDecoder.java
@@ -77,6 +77,8 @@ public interface CharsetDeciderDecoder {
 		new CharsetRecog_sbcs.CharsetRecog_windows_1256()
 	});
 	public static final CharsetRecognizer[] ALL_RECOGNIZERS = ArrayUtil.mergeNoDuplicates(CharsetRecognizer.class, EXPRESS_RECOGNIZERS, EUROPEAN, ARABIC, HEBREW, UNICODE);
+
+	public static final CharsetRecognizer[] FIXED = new CharsetRecognizer[] {new CharsetRecog_sbcs.CharsetRecog_windows_1251()};
 	
 	public static enum ERecognizerGroup {
 		EXPRESS {


### PR DESCRIPTION
Detecting the charset of single lines does not really work (see my
comment about that[1]), so we're dropping this attempt for now, and
instead assume an arbitrary single byte character set.  This lets all
ten reported failing tests pass.

[1] <https://github.com/php/pftt2/issues/63#issuecomment-553351697>

---

If we're going this way, there is of course no need to use `CharsetDeciderDecoder` and related classes any longer, and we could simplify. Before investing more time in this, we should decide whether we want to do this.

@lavturo, @weltling, what do you think?