### PR TITLE
Updating scripts to not use bitsadmin

### DIFF
--- a/bin/download_files.ps1
+++ b/bin/download_files.ps1
@@ -1,0 +1,11 @@
+Param([string]$url, [string]$path, [string]$file_name)
+
+If ($url -eq "" -or $path -eq "" -or $file_name -eq "") {
+	Write-Output "User error: Must specifiy url, save path and file name"
+	Write-Output "download_file <url> <path to dir> <desired file name>"
+}
+
+Import-Module BitsTransfer
+
+Write-Host "Downloading" $file_name"..." -ForegroundColor Green
+	Start-BitsTransfer -Source $url -Destination $path

--- a/bin/get_latest_revision.cmd
+++ b/bin/get_latest_revision.cmd
@@ -1,6 +1,6 @@
 set SNAP_JSON=php-%branch%.json
 set SNAP_JSON_URL=https://windows.php.net/downloads/snaps/php-%branch%/%SNAP_JSON%
-bitsadmin /transfer DownloadingJson /download /priority high !SNAP_JSON_URL! %PFTT_CACHE%\!SNAP_JSON!
+powershell download_files.ps1 !SNAP_JSON_URL! %PFTT_CACHE% !SNAP_JSON!
 
 set "psCmd="add-type -As System.Web.Extensions;^
 $JSON = new-object Web.Script.Serialization.JavaScriptSerializer;^

--- a/bin/get_qa.cmd
+++ b/bin/get_qa.cmd
@@ -53,7 +53,7 @@ REM Download the build if it is not available
 if not exist %PHP_BUILDS%\%file_name% (
 	set build_link=https://windows.php.net/downloads/qa/%file_name%.zip
 
-	bitsadmin /transfer DownloadingQABuild /download /priority high !build_link! %PFTT_CACHE%\%file_name%.zip
+	powershell download_files.ps1 !build_link! %PFTT_CACHE% %file_name%.zip
 	7za.exe x %PFTT_CACHE%\%file_name%.zip -o%PHP_BUILDS%\*
 	del %PFTT_CACHE%\%file_name%.zip
 ) else (
@@ -64,7 +64,7 @@ REM Also download test-pack if it is not available
 if not exist %PHP_BUILDS%\%test_pack% (
 	set test_pack_link=https://windows.php.net/downloads/qa/%test_pack%.zip
 
-	bitsadmin /transfer DownloadingQATestPack /download /priority high !test_pack_link! %PFTT_CACHE%\%test_pack%.zip
+	powershell download_files.ps1 !test_pack_link! %PFTT_CACHE% %test_pack%.zip
 	7za.exe x %PFTT_CACHE%\%test_pack%.zip -o%PHP_BUILDS%\*
 	del %PFTT_CACHE%\%test_pack%.zip
 ) else (

--- a/bin/get_release.cmd
+++ b/bin/get_release.cmd
@@ -58,7 +58,7 @@ REM Download the build if it is not available
 if not exist %PHP_BUILDS%\%file_name% (
 	set build_link=https://windows.php.net/downloads/releases/latest/%file_name%.zip
 
-	bitsadmin /transfer DownloadingReleaseBuild /download /priority high !build_link! %PFTT_CACHE%\%file_name%.zip
+	powershell download_files.ps1 !build_link! %PFTT_CACHE% %file_name%.zip
 	7za.exe x %PFTT_CACHE%\%file_name%.zip -o%PHP_BUILDS%\*
 	del %PFTT_CACHE%\%file_name%.zip
 ) else (
@@ -69,7 +69,7 @@ REM Also download test-pack if it is not available
 if not exist %PHP_BUILDS%\%test_pack% (
 	set test_pack_link=https://windows.php.net/downloads/releases/latest/%test_pack%.zip
 
-	bitsadmin /transfer DownloadingReleaseTestPack /download /priority high !test_pack_link! %PFTT_CACHE%\%test_pack%.zip
+	powershell download_files.ps1 !test_pack_link! %PFTT_CACHE% %test_pack%.zip
 	7za.exe x %PFTT_CACHE%\%test_pack%.zip -o%PHP_BUILDS%\*
 	del %PFTT_CACHE%\%test_pack%.zip
 ) else (

--- a/bin/get_snapshot.cmd
+++ b/bin/get_snapshot.cmd
@@ -60,7 +60,7 @@ REM Download the build if it is not available
 if not exist %PHP_BUILDS%\%file_name% (
 	set build_link=https://windows.php.net/downloads/snaps/php-%branch%/%revision%/%file_name%.zip
 
-	bitsadmin /transfer DownloadingSnap-%branch%-%build%-%cpu%-Build /download /priority high !build_link! %PFTT_CACHE%\%file_name%.zip
+	powershell download_files.ps1 !build_link! %PFTT_CACHE% %file_name%.zip
 	7za.exe x %PFTT_CACHE%\%file_name%.zip -o%PHP_BUILDS%\*
 	del %PFTT_CACHE%\%file_name%.zip
 ) else (
@@ -71,7 +71,7 @@ REM Also download test-pack if it is not available
 if not exist %PHP_BUILDS%\%test_pack% (
 	set test_pack_link=https://windows.php.net/downloads/snaps/php-%branch%/%revision%/%test_pack%.zip
 
-	bitsadmin /transfer DownloadingSnap-%branch%-%build%-%cpu%-TestPack /download /priority high !test_pack_link! %PFTT_CACHE%\%test_pack%.zip
+	powershell download_files.ps1 !test_pack_link! %PFTT_CACHE% %test_pack%.zip
 	7za.exe x %PFTT_CACHE%\%test_pack%.zip -o%PHP_BUILDS%\*
 	del %PFTT_CACHE%\%test_pack%.zip
 ) else (


### PR DESCRIPTION
There was an issue with using bitsadmin (a command for windows cmd line) on azure apps. Trying to change the script to not use it. 