### PR TITLE
Fixes #76: ArrayOutOfBounds exception fixed

### DIFF
--- a/src/com/mostc/pftt/main/PfttMain.java
+++ b/src/com/mostc/pftt/main/PfttMain.java
@@ -758,8 +758,13 @@ public class PfttMain {
 					cm.showGUI(test_pack_runner);
 					
 					test_pack_runner.runTestList(test_pack, test_cases);
-				
-					tmgr.notifyPhptFinished(host, test_pack_runner.getScenarioSetSetup(), test_pack);
+					
+					ScenarioSetSetup scenarioSetSetup = test_pack_runner.getScenarioSetSetup();
+					if(scenarioSetSetup == null) {
+						return;
+					}
+					
+					tmgr.notifyPhptFinished(host, scenarioSetSetup, test_pack);
 					if (!run_flag.get())
 						return;
 				}

--- a/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
+++ b/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
@@ -236,7 +236,6 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 	}
 	
 	protected void runTestList(ITestPackStorageDir storage_dir, S test_pack, A active_test_pack, List<T> test_cases) throws Exception {
-		scenario_set_setup = ScenarioSetSetup.setupScenarioSet(cm, runner_fs, runner_host, build, scenario_set, getScenarioSetPermutationLayer());
 		if (test_cases.isEmpty()) {
 			if (cm!=null)
 				cm.println(EPrintType.COMPLETED_OPERATION, getClass(), "no test cases to run. did nothing.");
@@ -256,6 +255,7 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 		checkHost(storage_host);
 		checkHost(runner_host);
 //		AzureWebsitesScenario.first = true; // TODO temp azure
+		scenario_set_setup = ScenarioSetSetup.setupScenarioSet(cm, runner_fs, runner_host, build, scenario_set, getScenarioSetPermutationLayer());
 		if (scenario_set_setup==null)
 			return;
 		

--- a/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
+++ b/src/com/mostc/pftt/runner/AbstractLocalTestPackRunner.java
@@ -236,6 +236,7 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 	}
 	
 	protected void runTestList(ITestPackStorageDir storage_dir, S test_pack, A active_test_pack, List<T> test_cases) throws Exception {
+		scenario_set_setup = ScenarioSetSetup.setupScenarioSet(cm, runner_fs, runner_host, build, scenario_set, getScenarioSetPermutationLayer());
 		if (test_cases.isEmpty()) {
 			if (cm!=null)
 				cm.println(EPrintType.COMPLETED_OPERATION, getClass(), "no test cases to run. did nothing.");
@@ -255,7 +256,6 @@ public abstract class AbstractLocalTestPackRunner<A extends ActiveTestPack, S ex
 		checkHost(storage_host);
 		checkHost(runner_host);
 //		AzureWebsitesScenario.first = true; // TODO temp azure
-		scenario_set_setup = ScenarioSetSetup.setupScenarioSet(cm, runner_fs, runner_host, build, scenario_set, getScenarioSetPermutationLayer());
 		if (scenario_set_setup==null)
 			return;
 		


### PR DESCRIPTION
`scenario_set_setup` was null. So `PhpResultPackWriter` would always throw an [exception](https://github.com/php/pftt2/blob/94eb81a9e90be9f8ad1f576d9bf043e7952cc81a/src/com/mostc/pftt/results/PhpResultPackWriter.java#L638). 

Simply moving this `scenario_set_up` call before it returns when there are no tests available fixes that issue. 